### PR TITLE
Update README.md to use the effective user id instead of 1000

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Maven needs the user home to download artifacts to, and if the user does not exi
 
 For example, to run as the current user (instead of root), mounting the host Maven repo (at `~/.m2`)
 
-    docker run -v ~/.m2:/var/maven/.m2 -ti --rm -u $(id -u) -e MAVEN_CONFIG=/var/maven/.m2 maven mvn -Duser.home=/var/maven archetype:generate
+    docker run -v ~/.m2:/var/maven/.m2 -it --rm -u $(id -u) -e MAVEN_CONFIG=/var/maven/.m2 maven mvn -Duser.home=/var/maven archetype:generate
 
 
 # Image Variants

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Maven needs the user home to download artifacts to, and if the user does not exi
 
 For example, to run as user `1000` mounting the host' Maven repo
 
-    docker run -v ~/.m2:/var/maven/.m2 -ti --rm -u 1000 -e MAVEN_CONFIG=/var/maven/.m2 maven mvn -Duser.home=/var/maven archetype:generate
+    docker run -v ~/.m2:/var/maven/.m2 -ti --rm -u $(id -u) -e MAVEN_CONFIG=/var/maven/.m2 maven mvn -Duser.home=/var/maven archetype:generate
 
 
 # Image Variants

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ For an example, check the `tests` dir
 Maven needs the user home to download artifacts to, and if the user does not exist in the image an extra
 `user.home` Java property needs to be set.
 
-For example, to run as user `1000` mounting the host' Maven repo
+For example, to run as the current user (instead of root), mounting the host Maven repo (at `~/.m2`)
 
     docker run -v ~/.m2:/var/maven/.m2 -ti --rm -u $(id -u) -e MAVEN_CONFIG=/var/maven/.m2 maven mvn -Duser.home=/var/maven archetype:generate
 


### PR DESCRIPTION
Replace `-u 1000` by the actual id of the user.

See https://man7.org/linux/man-pages/man1/id.1.html

Tested:
On Mac OS and Linux